### PR TITLE
DT-548 Fix video and audio in epiphany

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -34,6 +34,10 @@ apps:
     command: bin/snapcraft-preload $SNAP/usr/bin/epiphany
     extensions: [ gnome ]
     plugs:
+      - audio-playback
+      - audio-record
+      - browser-support
+      - camera
       - cups
       - hardware-observe
       - home
@@ -43,7 +47,6 @@ apps:
       - network-status
       - opengl
       - password-manager-service
-      - pulseaudio
       - removable-media
       - screen-inhibit-control
       - upower-observe
@@ -51,7 +54,7 @@ apps:
     environment:
       GSETTINGS_SCHEMA_DIR: $SNAP/share/glib-2.0/schemas
       GIO_MODULE_DIR: $SNAP/snap/epiphany/current/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET/gio/modules/
-      LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/epiphany
+      LD_LIBRARY_PATH: ${LD_LIBRARY_PATH:+$LD_LIBRARY_PATH:}$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/epiphany:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET/blas
 
 parts:
 # epiphany needs access to /dev/shm/


### PR DESCRIPTION
When accesing a web page with video (like youtube), epiphany
shown several warnings, notifying that it can't load several
GST plugins.

This patch fixes that, thus allowing to play videos. Also add
the necessary interfaces for video, audio and webcam.

Fix https://github.com/ubuntu/epiphany/issues/2