### PR TITLE
bump automation extension version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -80,7 +80,7 @@ parts:
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '43'
+#     lower-than: '46'
 #     no-9x-revisions: true
     plugin: meson
     parse-info: [usr/share/metainfo/org.gnome.Epiphany.appdata.xml]


### PR DESCRIPTION
bumping automation extension version to pull gnome 45 tags