### PR TITLE
build: bump max upstream version

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -102,7 +102,7 @@ parts:
     after: [snapcraft-preload, gcr]
     source: https://gitlab.gnome.org/GNOME/epiphany.git
     source-type: git
-    source-tag: '45.3'
+    source-tag: '46.0'
     source-depth: 1
 # ext:updatesnap
 #   version-format:

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -106,7 +106,7 @@ parts:
     source-depth: 1
 # ext:updatesnap
 #   version-format:
-#     lower-than: '46'
+#     lower-than: '47'
 #     no-9x-revisions: true
     plugin: meson
     parse-info: [usr/share/metainfo/org.gnome.Epiphany.appdata.xml]


### PR DESCRIPTION
This pull request enables the snap to be updated to gnome 46 by the automation
