### PR TITLE
Add system-observe plug

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -50,6 +50,7 @@ apps:
       - password-manager-service
       - removable-media
       - screen-inhibit-control
+      - system-observe
       - upower-observe
     desktop: usr/share/applications/org.gnome.Epiphany.desktop
     environment:


### PR DESCRIPTION
WebKit's Memory Pressure Monitor requires access to /proc/zoneinfo
    https://github.com/WebKit/webkit/blob/main/Source/WebKit/UIProcess/linux/MemoryPressureMonitor.cpp#L363

Without this access, AppArmor generates a significant amount of denials, cluttering the journal.

# Pull Request Template

## Description

This enables the system-observe plug so that WebKit's memory pressure monitor can access /proc/zoneinfo.

## Type of change

Please check only the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Without this plug, AppArmor will record a number of denials such as:

```
Jul 18 23:50:45 deadpool kernel: audit: type=1400 audit(1752897045.768:4277): apparmor="DENIED" operation="open" class="file" profile="snap.epiphany.epiphany" name="/proc/zoneinfo" pid=63946 comm="PressureMonitor" requested_mask="r" denied_mask="r" fsuid=1000 ouid=0
```

With this plug enabled and connecting it with `snap connect epiphany:system-observe`, these denial messages no longer appear.

**Test Configuration**:

Ubuntu 24.04.2

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

