### PR TITLE
Add mpris slot

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -23,6 +23,10 @@ slots:
     interface: dbus
     bus: session
     name: org.gnome.Epiphany
+  mpris:
+    # Since WebKit uses org.gnome.Epiphany as the name, but snapd does not
+    # allow ".", just use org for name
+    name: org
 
 layout:
   /usr/share/epiphany:
@@ -51,6 +55,8 @@ apps:
       - removable-media
       - screen-inhibit-control
       - upower-observe
+    slots:
+      - mpris
     desktop: usr/share/applications/org.gnome.Epiphany.desktop
     environment:
       GSETTINGS_SCHEMA_DIR: $SNAP/usr/share/glib-2.0/schemas


### PR DESCRIPTION
# Pull Request Template

## Description

This allows Epiphany to report what media is playing (ie. YouTube video) via MPRIS and allows for third-party control of the media playback as shown below:

<img width="1920" height="1080" alt="Screenshot from 2025-07-21 09-44-30" src="https://github.com/user-attachments/assets/4b8b0859-fd6c-4ea5-94d0-5d7678641dfc" />

As explained in the comment, `snapd` does not allow for MPRIS names that contains dots due to this regex:

https://github.com/canonical/snapd/blob/master/interfaces/builtin/mpris.go#L215

However, WebKit creates the MPRIS DBUS name based on the `gtk_application_id`, which in this case is `org.gnome.Epiphany`.  This is an issue due to the `snapd` restriction above.

Rather than patching Epiphany to use a shorten version of the `gtk_application_id`, it is easier to just tell `snapd` to allow for `org` as the MPRIS name.  This leads to the following AppArmor rule:

```
# https://specifications.freedesktop.org/mpris-spec/latest/
# allow binding to the well-known DBus mpris interface based on the snap's name
dbus (bind)
    bus=session
    name="org.mpris.MediaPlayer2.org{,.*}",
```

Which allows Epiphany to bind to the MPRIS DBUS session.

## Type of change

Please check only the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I played a YouTube video and then looked in GNOME to see if the video has playback controls in the notification center as shown in the screenshot.  I was able to pause and play the video from the notification controls.

**Test Configuration**:

Ubuntu 24.04.2

## Checklist:

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings

